### PR TITLE
Fix extconf to work on ruby 2.2

### DIFF
--- a/example.rb
+++ b/example.rb
@@ -1,15 +1,19 @@
 require 'rbhelium'
 require 'base64'
 
-token = Base64.decode64("C8Slmiwm6dreZrUhy5YPiA==")
+Thread.abort_on_exception = true
 
-conn = Helium::Connection.new do |mac, datums|
+token = Base64.decode64("PbOkU4Jo+NObbPe27MJGNQ==")
+
+conn = Helium::Connection.new("r01.sjc.helium.io") do |mac, datums|
   puts "Got data #{datums} from mac #{mac}"
 end
 
 puts "subscribing..."
 
-status = conn.subscribe(0x0000112233440001, token)
+status = conn.subscribe(0x000000fffff00002, token)
+
+conn.write(0x000000fffff00002, token, "hello from ruby #{Process.pid}")
 
 puts "status: #{status}"
 

--- a/ext/rbhelium/extconf.rb
+++ b/ext/rbhelium/extconf.rb
@@ -6,7 +6,7 @@ def must_have(type, ident)
 end
 
 must_have :header, 'ruby.h'
-must_have :func, 'rb_thread_blocking_region'
+must_have :func, 'rb_thread_call_without_gvl'
 must_have :library, 'pthread'
 must_have :library, 'helium'
 must_have :library, 'crypto'


### PR DESCRIPTION
I've tested the new extconf with ruby 2.0, 2.1 and 2.2 and they all work
with the new symbol check.

I've also updated the example.rb file to be more useful for testing.

cc @patrickt 